### PR TITLE
 PB-34 Unused variables

### DIFF
--- a/tests/components/zha/test_cluster_handlers.py
+++ b/tests/components/zha/test_cluster_handlers.py
@@ -266,8 +266,6 @@ async def test_in_cluster_handler_config(
     assert cluster.bind.call_count == bind_count
     assert cluster.configure_reporting.call_count == 0
     assert cluster.configure_reporting_multiple.call_count == math.ceil(len(attrs) / 3)
-    reported_attrs = set(attrs)
-    assert set(attrs) == reported_attrs
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zha/test_cluster_handlers.py
+++ b/tests/components/zha/test_cluster_handlers.py
@@ -266,12 +266,7 @@ async def test_in_cluster_handler_config(
     assert cluster.bind.call_count == bind_count
     assert cluster.configure_reporting.call_count == 0
     assert cluster.configure_reporting_multiple.call_count == math.ceil(len(attrs) / 3)
-    reported_attrs = {
-        a
-        for a in attrs
-        for attr in cluster.configure_reporting_multiple.call_args_list
-        for attrs in attr[0][0]
-    }
+    reported_attrs = set(attrs)
     assert set(attrs) == reported_attrs
 
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1124,7 +1124,7 @@ async def test_strategy_no_network_settings(
     """Test formation strategy when no network settings are present."""
     mock_app.load_network_info = MagicMock(side_effect=NetworkNotFormed())
 
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
     assert (
         config_flow.FORMATION_REUSE_SETTINGS
         not in result["data_schema"].schema["next_step_id"].container
@@ -1135,7 +1135,7 @@ async def test_formation_strategy_form_new_network(
     pick_radio, mock_app, hass: HomeAssistant
 ) -> None:
     """Test forming a new network."""
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -1155,7 +1155,7 @@ async def test_formation_strategy_form_initial_network(
     """Test forming a new network, with no previous settings on the radio."""
     mock_app.load_network_info = AsyncMock(side_effect=NetworkNotFormed())
 
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"next_step_id": config_flow.FORMATION_FORM_INITIAL_NETWORK},
@@ -1207,7 +1207,7 @@ async def test_formation_strategy_reuse_settings(
     pick_radio, mock_app, hass: HomeAssistant
 ) -> None:
     """Test reusing existing network settings."""
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -1240,7 +1240,7 @@ async def test_formation_strategy_restore_manual_backup_non_ezsp(
     allow_overwrite_ieee_mock, pick_radio, mock_app, hass: HomeAssistant
 ) -> None:
     """Test restoring a manual backup on non-EZSP coordinators."""
-    result, port = await pick_radio(RadioType.znp)
+    result, _ = await pick_radio(RadioType.znp)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -1272,7 +1272,7 @@ async def test_formation_strategy_restore_manual_backup_overwrite_ieee_ezsp(
     allow_overwrite_ieee_mock, pick_radio, mock_app, backup, hass: HomeAssistant
 ) -> None:
     """Test restoring a manual backup on EZSP coordinators (overwrite IEEE)."""
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -1312,7 +1312,7 @@ async def test_formation_strategy_restore_manual_backup_ezsp(
     allow_overwrite_ieee_mock, pick_radio, mock_app, hass: HomeAssistant
 ) -> None:
     """Test restoring a manual backup on EZSP coordinators (don't overwrite IEEE)."""
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -1353,7 +1353,7 @@ async def test_formation_strategy_restore_manual_backup_invalid_upload(
     pick_radio, mock_app, hass: HomeAssistant
 ) -> None:
     """Test restoring a manual backup but an invalid file is uploaded."""
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
 
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -1413,7 +1413,7 @@ async def test_formation_strategy_restore_automatic_backup_ezsp(
     backup = mock_app.backups.backups[1]  # pick the second one
     backup.is_compatible_with = MagicMock(return_value=False)
 
-    result, port = await pick_radio(RadioType.ezsp)
+    result, _ = await pick_radio(RadioType.ezsp)
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"next_step_id": (config_flow.FORMATION_CHOOSE_AUTOMATIC_BACKUP)},
@@ -1462,7 +1462,7 @@ async def test_formation_strategy_restore_automatic_backup_non_ezsp(
     backup = mock_app.backups.backups[1]  # pick the second one
     backup.is_compatible_with = MagicMock(return_value=False)
 
-    result, port = await pick_radio(RadioType.znp)
+    result, _ = await pick_radio(RadioType.znp)
 
     with patch(
         "homeassistant.config_entries.ConfigFlow.show_advanced_options",
@@ -1511,7 +1511,7 @@ async def test_ezsp_restore_without_settings_change_ieee(
     with patch.object(
         mock_app, "load_network_info", MagicMock(side_effect=NetworkNotFormed())
     ):
-        result, port = await pick_radio(RadioType.ezsp)
+        result, _ = await pick_radio(RadioType.ezsp)
 
     # Set the network state, it'll be picked up later after the load "succeeds"
     mock_app.state.node_info = backup.node_info

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -368,7 +368,7 @@ async def test_action(hass: HomeAssistant, device_ias, device_inovelli) -> None:
 
 async def test_invalid_zha_event_type(hass: HomeAssistant, device_ias) -> None:
     """Test that unexpected types are not passed to `zha_send_event`."""
-    zigpy_device, zha_device = device_ias
+    _, zha_device = device_ias
     cluster_handler = zha_device._endpoints[1].client_cluster_handlers["1:0x0006"]
 
     # `zha_send_event` accepts only zigpy responses, lists, and dicts

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -153,7 +153,7 @@ async def test_zha_logbook_event_device_no_triggers(
 ) -> None:
     """Test ZHA logbook events with device and without triggers."""
 
-    zigpy_device, zha_device = mock_devices
+    _, zha_device = mock_devices
     ieee_address = str(zha_device.ieee)
     ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The changes remove and alter unused variables in zha tests to improve maintainability and readability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes PB-34
- This PR is related to issue: Unused variables
- Link to documentation pull request: https://software-evolution-project-2023-group10.atlassian.net/jira/software/projects/PB/boards/1?selectedIssue=PB-34

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
