### PR TITLE
Pb 27 cognitive complexity

### DIFF
--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -219,6 +219,11 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
     LOGGER.info("Migration of devices and entities to support API schema 2 finished")
 
 
+###
+# Support functions.
+###
+
+
 def build_device_ids(device_reg, entry_id):
     """Build a mapping of mac address to HA device id's."""
     dev_ids = {}

--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -84,13 +84,6 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
     # but in some cases it has a postfix like `-0b` or `-01`.
     dev_ids = build_device_ids(dev_reg, entry.entry_id)
 
-    for hass_dev in devices_for_config_entries(dev_reg, entry.entry_id):
-        for domain, mac in hass_dev.identifiers:
-            if domain != DOMAIN:
-                continue
-            normalized_mac = mac.split("-")[0]
-            dev_ids[normalized_mac] = hass_dev.id
-
     # initialize bridge connection just for the migration
     async with HueBridgeV2(host, api_key) as api:
         sensor_class_mapping = {
@@ -181,7 +174,7 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
 
         # migrate entities that are not connected to a device (groups)
         for ent in entities_for_config_entry(ent_reg, entry.entry_id):
-            if ent.device_id is not None:
+            if ent.device_id:
                 continue
             if "-" in ent.unique_id:
                 # handle case where unique id is v2-id of group/zone

--- a/homeassistant/components/hue/migration.py
+++ b/homeassistant/components/hue/migration.py
@@ -82,7 +82,8 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
     # Create mapping of mac address to HA device id's.
     # Identifier in dev reg should be mac-address,
     # but in some cases it has a postfix like `-0b` or `-01`.
-    dev_ids = {}
+    dev_ids = build_device_ids(dev_reg, entry.entry_id)
+
     for hass_dev in devices_for_config_entries(dev_reg, entry.entry_id):
         for domain, mac in hass_dev.identifiers:
             if domain != DOMAIN:
@@ -216,3 +217,15 @@ async def handle_v2_migration(hass: core.HomeAssistant, entry: ConfigEntry) -> N
                     ent.entity_id,
                 )
     LOGGER.info("Migration of devices and entities to support API schema 2 finished")
+
+
+def build_device_ids(device_reg, entry_id):
+    """Build a mapping of mac address to HA device id's."""
+    dev_ids = {}
+    for hass_dev in devices_for_config_entries(device_reg, entry_id):
+        for domain, mac in hass_dev.identifiers:
+            if domain != DOMAIN:
+                continue
+            normalized_mac = mac.split("-")[0]
+            dev_ids[normalized_mac] = hass_dev.id
+    return dev_ids


### PR DESCRIPTION
## Proposed change
<!--
This refactor splits the original function into a smaller helper function. It not only reduces the cognitive complexity but also makes the code more maintainable and readable. 
-->


## Type of change
<!--
  Refactoring function in migration.py
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
-->

- This PR fixes or closes issue: fixes  PB-27
- This PR is related to issue:  Cognitive complexity
- Link to documentation pull request:  https://software-evolution-project-2023-group10.atlassian.net/browse/PB-27?atlOrigin=eyJpIjoiZjBkMmUyZTM0ZTNiNDcxYTk2NWE1NmY1ZjBlYTgzMTkiLCJwIjoiaiJ9

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.
